### PR TITLE
Add figaro to project to hide api key from public on github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,5 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
 end
+
+gem "figaro", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,9 +68,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
-    bcrypt (3.1.18)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
+    bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.13.0)
       msgpack (~> 1.2)
@@ -97,6 +97,8 @@ GEM
     execjs (2.8.1)
     ffi (1.15.5)
     ffi (1.15.5-x64-mingw-ucrt)
+    figaro (1.2.0)
+      thor (>= 0.14.0, < 2)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -229,6 +231,7 @@ DEPENDENCIES
   capybara
   debug
   ffi
+  figaro (~> 1.2)
   importmap-rails
   jbuilder
   puma (~> 5.0)

--- a/app/views/map/index.html.erb
+++ b/app/views/map/index.html.erb
@@ -10,7 +10,7 @@
 <h3>My Google Maps Demo</h3>
 <div id="map"></div>
 <script
-  src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDe4lIvg71LTj7DvY0_edNlB4opW4h2Rho&callback=initMap&v=weekly"
+  src="https://maps.googleapis.com/maps/api/js?key=<%= Figaro.env.MAP_API %>&callback=initMap&v=weekly"
   defer
 ></script>
 </body>


### PR DESCRIPTION
IN ORDER TO USE YOUR API KEY FOR GOOGLE MAPS:

Run this:
```
bundle install
bundle exec figaro install
```
Press y if prompted.

Inside config/application.yml
Add the line
```MAP_API: YOUR-API-KEY```
Replace YOUR-API-KEY with your API key.